### PR TITLE
Remove explicit ownership for installed files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PROGNAME = tetris$(EXE)
 # Uncomment to change the default.  (Only used in Unix-like systems.)
 #HISCORE_FILENAME = /var/games/vitetris-hiscores
 
-INSTALL = install -oroot -groot
+INSTALL = install
 
 default: build
 	@echo Done.


### PR DESCRIPTION
The makefile shouldn't force the ownership of installed files. That will prevent users from installing without root privileges under a user owned directory (using `DESTDIR`).