### PR TITLE
Avoid compiler error with -Werror=format-security

### DIFF
--- a/src/netw/gameserver.c
+++ b/src/netw/gameserver.c
@@ -615,7 +615,7 @@ int main(int argc, char **argv)
 			write_logfile(argv[2]);
 		if (time(NULL)-t > 12*60*60) {
 			time(&t);
-			printf(ctime(&t));
+			printf("%s", ctime(&t));
 		}
 	}
 	return 0;


### PR DESCRIPTION
When GCC is run with -Werror=format-security, it aborts the compilation because
it considers printf(ctime(&t)) at risk for string format injection. This should
not be possible anyway when using the unchanged output of ctime()), but we can
avoid the compiler warning by providing a format string and using ctime(&t)
merely as an argument.

Original report and proposed fix:
- https://aur.archlinux.org/packages/vitetris#comment-817850
- https://aur.archlinux.org/packages/vitetris#comment-833456