### PR TITLE
Add void return type to init_field prototype

### DIFF
--- a/src/menu/netplay.c
+++ b/src/menu/netplay.c
@@ -17,7 +17,7 @@ static char name_str[18];
 
 static int cursor = -1;
 
-static init_field(char *str, const char *val, int maxlen)
+static void init_field(char *str, const char *val, int maxlen)
 {
 	memset(str, ' ', maxlen+1);
 	if (val) {


### PR DESCRIPTION
As originally reported in Debian bug report [#1075624](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1075624), vitetris does not build with GCC-14 new defaults.

This is due to a missing return type in `src/menu/netplay.c`, in the static function `init_field`.

This PR adds the `void` return type, fixing the issue with GCC-14.

Let me know if you intend to release a new version in the near future with this fix, otherwise, I'll patch it directly in the packaging.

Best,