### PR TITLE
Fix compile error against glibc 2.40

### DIFF
--- a/src/netw/tty_socket.c
+++ b/src/netw/tty_socket.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <ctype.h>
 #include <unistd.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Sometime between glibc 2.38 and glibc 2.40, usage of `time()` required `time.h`.

Full error message seen:

```
make[2]: Entering directory '/usr/src/git/vitetris/src/netw'
ccache cc -O2  -I.. -c socket.c
ccache cc -O2  -I.. -c comm.c
ccache cc -O2  -I.. -c inet.c
ccache cc -O2       -c tty_socket.c
tty_socket.c: In function 'add_2p_tty':
tty_socket.c:128:13: error: implicit declaration of function 'time' [-Wimplicit-function-declaration]
  128 |         if (time(NULL) - st.st_mtime > 3600) {
      |             ^~~~
tty_socket.c:16:1: note: 'time' is defined in header '<time.h>'; this is probably fixable by adding '#include <time.h>'
   15 | #include "internal.h"
  +++ |+#include <time.h>
   16 |
```

My version info:
- GCC 14.2.0
- glibc 2.40
- Slackware Linux (-current) x86_64

My local `config.h` additions (by running `configure`):
```diff
diff --git a/src/config.h b/src/config.h
index fb55819..55fd5c4 100644
--- a/src/config.h
+++ b/src/config.h
@@ -1,4 +1,12 @@
+/* Generated by configure */
 #ifndef config_h
 #define config_h
+
+#define HAVE_STDINT_H 1
+#define HAVE_SYS_TYPES_H 1
+#define HAVE_UINT_LEAST32_T 1
+#define HAVE_SYS_SELECT_H 1
+
 #include "config2.h"
+
 #endif
```