### PR TITLE
Fix for musl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ PROGNAME = tetris$(EXE)
 
 INSTALL = install
 
+CFLAGS += -lssp
+
 default: build
 	@echo Done.
 	@echo 'Now run ./$(PROGNAME) (or make install)'

--- a/src/menu/netplay.c
+++ b/src/menu/netplay.c
@@ -17,7 +17,7 @@ static char name_str[18];
 
 static int cursor = -1;
 
-static init_field(char *str, const char *val, int maxlen)
+static void init_field(char *str, const char *val, int maxlen)
 {
 	memset(str, ' ', maxlen+1);
 	if (val) {

--- a/src/netw/tty_socket.c
+++ b/src/netw/tty_socket.c
@@ -13,6 +13,7 @@
 #include <errno.h>
 #include "sock.h"
 #include "internal.h"
+#include <time.h>
 
 const struct invit *invit = NULL;
 char this_tty[8] = "";


### PR DESCRIPTION
This pull request includes several changes to the `Makefile` and source files to improve functionality and code quality. The most important changes include adding a compiler flag, fixing a function definition, and including a necessary header file.

Build configuration:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R10-R11): Added the `-lssp` flag to `CFLAGS` to enable stack smashing protection.

Code improvements:

* [`src/menu/netplay.c`](diffhunk://#diff-66e680aec1a9c4d303f6637135c48d989a8aa19569be96f812ed4143dd5c0c55L20-R20): Changed the `init_field` function to include the `void` return type for better clarity and correctness.
* [`src/netw/tty_socket.c`](diffhunk://#diff-d27348179b0f7f05ad0c0001646ba4c5f921834cf6b6d2751d7060e8b028a358R16): Included the `<time.h>` header file to ensure time-related functions are available.